### PR TITLE
Migrrate HTTP::Handler to Crystal 0.20 usage

### DIFF
--- a/src/crux/node.cr
+++ b/src/crux/node.cr
@@ -1,7 +1,9 @@
 require "http"
 
 module Crux
-  class Node < HTTP::Handler
+  class Node
+    include HTTP::Handler
+
     property matcher : Crux::Matcher::Matchable
     property! handler : HTTP::Handler | HTTP::Handler::Proc
     property children = Array(self).new


### PR DESCRIPTION
In 0.20 HTTP::Handler changed from a class to a module. This commit
makes the relevant change.